### PR TITLE
CS-4613 Fixes hidden attribute declaration for svg in FileUpload model

### DIFF
--- a/src/Models/FileUpload.php
+++ b/src/Models/FileUpload.php
@@ -17,6 +17,8 @@ class FileUpload extends Model
      */
     protected $table = 'file_uploads';
 
+    protected $hidden = ['svg'];
+
     /**
      * Mass assignable fields
      *


### PR DESCRIPTION
This hides the svg attribute from JSON responses by adding it to $hidden. The raw binary content was causing Malformed UTF-8 exceptions when serializing models like FileUpload via API or resource collections.

